### PR TITLE
Update lupus.php

### DIFF
--- a/assets/lupus.php
+++ b/assets/lupus.php
@@ -166,20 +166,19 @@ $roles = array(
             'ceo' => 'amministrazione',
             'portavoce' => 'amministrazione',
             
+            // replicanti
+            'collaboratore' => 'replicanti',
+            'I.A.' => 'replicanti',
+            'virus' => 'replicanti',
+            'replicante' => 'replicanti',
+        
             // ribelli
             'cancellatore' => 'ribelli',
-            'collaboratore' => 'ribelli',
             'coordinatore' => 'ribelli',
-            'I.A.' => 'ribelli',
-            'infiltrato' => 'ribelli',
-            'virus' => 'ribelli',
+            'informatore' => 'ribelli',
             'lurker' => 'ribelli',
             'man in the middle' => 'ribelli',
-            'replicante' => 'ribelli',
             'sosia' => 'ribelli',
-            
-            // programmatori
-            'programmatore' => 'programmatori',
             
             // simbionti
             'simbionte' => 'simbionti',


### PR DESCRIPTION
Roles of the replicanti faction are now correctly placed (they were assigned to ribelli faction)
removed programmatore
changed name of infiltrato to informatore